### PR TITLE
Fix #1 - Create a new queue after rescuing pending commands

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -62,7 +62,7 @@ Connection.prototype.rescuePending = function () {
     var command = this.pendingQueue.pop()
     if (command.name !== 'debug') this.queue.unshift(command)
   }
-  this.pendingQueue = null
+  this.pendingQueue = new Queue()
   return this
 }
 


### PR DESCRIPTION
Tested this using the same procedure I outlined in #1 and it resolves the crash. Following your style guide of not using semicolons :stuck_out_tongue_closed_eyes:
