### PR TITLE
Fix toHash when disque returns (nil) to a query

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -85,6 +85,9 @@ function adjustArgs (args) {
 }
 
 function toHash (array) {
+  // disque returned (nil)
+  if (!array) return null
+
   let hash = {}
 
   for (let i = 0, len = array.length; i < len; i += 2) {


### PR DESCRIPTION
Hi,

Thanks for maintaining thunk-disque. This is great to already have a library for disque which has been released lately. 
I am currently using it to develop a task-queue library and I ran across the problem of failing queries when disque returns `(nil)`:

```
/Users/jpreynat/Gitbook/node-tasqueue/node_modules/thunk-disque/lib/commands.js:90
  for (let i = 0, len = array.length; i < len; i += 2) {
                             ^

TypeError: Cannot read property 'length' of null
    at DisqueClient.toHash (/Users/jpreynat/Gitbook/node-tasqueue/node_modules/thunk-disque/lib/commands.js:90:30)
    at Command._callback [as callback] (/Users/jpreynat/Gitbook/node-tasqueue/node_modules/thunk-disque/lib/connection.js:348:33)
    at Resp.<anonymous> (/Users/jpreynat/Gitbook/node-tasqueue/node_modules/thunk-disque/lib/connection.js:228:24)
    at emitOne (events.js:90:13)
    at Resp.emit (events.js:182:7)
    at Resp.write (/Users/jpreynat/Gitbook/node-tasqueue/node_modules/respjs/index.js:164:10)
    at Socket.ondata (_stream_readable.js:529:20)
    at emitOne (events.js:90:13)
    at Socket.emit (events.js:182:7)
    at readableAddChunk (_stream_readable.js:147:16)
```

My fix is simple yet I think this is enough to handle these use cases.
Thanks for taking it into account soon.

Kind regards,
Johan
