### PR TITLE
Fix deleting connection.sid from pool before disconnecting it

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -74,7 +74,6 @@ class Connection {
 
     let disqueState = this.disque._disqueState
     delete disqueState.pool[this.id]
-    delete disqueState.pool[this.sid]
     let index = disqueState.connections.indexOf(this.sid)
     if (index >= 0) disqueState.connections.splice(index, 1)
     disqueState.resetConnection()


### PR DESCRIPTION
Calling `client.clientEnd()` causes the following error:

``` JavaScript
TypeError: Cannot read property 'disconnect' of undefined
      at node_modules/thunk-disque/lib/client.js:88:17
      at Object.exports.each (node_modules/thunk-disque/lib/tool.js:39:59)
      at DisqueClient.clientEnd (node_modules/thunk-disque/lib/client.js:87:10)
      ...
```

Deleting the connection's `sid` from `disqueState.pool` in `lib/connection`:

``` JavaScript
  disconnect () {
    ...
    let disqueState = this.disque._disqueState
    delete disqueState.pool[this.id]
    delete disqueState.pool[this.sid] // faulty line
```

causes the `each` function to crash when reaching the actual connection's `sid` in `lib/client`:

``` JavaScript
    tool.each(disqueState.pool, (connection, key) => {
      connection.disconnect()
      delete disqueState.pool[key]
    })
```

Can you please take this PR into account for a `0.5.1` release ?

Thanks in advance.
