### PR TITLE
Ensure IP is used for auto-meet

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -291,6 +291,10 @@ function updateNodes (connection) {
       connection.priority = +res[0]
       connection.nid = res[1]
       connection.sid = res[1].slice(0, 8)
+      connection.nodes = res.slice(2).reduce((map, node) => {
+        map[node[0]] = node.slice(1, 3)
+        return map
+      }, {})
 
       let disqueState = connection.disque._disqueState
       disqueState.pool[connection.sid] = connection
@@ -316,7 +320,8 @@ function updateNodes (connection) {
 
 function meetNodes (src, dest) {
   let disque = src.disque
-  let ip = unwrapAddress(dest.id)
+  let destNode = dest.nodes[dest.nid]
+  let ip = destNode && destNode[0] !== '' ? destNode : unwrapAddress(dest.id)
   return disque._disqueState.thunk(function (callback) {
     let command = createCommand(disque, 'cluster', ['meet', ip[0], ip[1]], callback)
     if (command) src.writeCommand(command)


### PR DESCRIPTION
If hosts passed in when creating a client is not an IP address (e.g., myhost.mydomain.com), it seems that the meet functionality yields an error from disque when `autoMeet` is enabled, indicating that an IP address must be used. This change uses the result from the hello command to determine the IPs for the nodes in the cluster. Then it uses the IP in the meet command.

I am not sure if this is the ideal approach, but I am wondering if you would be open to such a change or if you had an alternative solution.
